### PR TITLE
Fix PyInstaller import error by using absolute imports (v0.1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "voice-replacer"
-version = "0.1.1"
+version = "0.1.2"
 description = "Real-time voice replacement using neural TTS"
 readme = "README.md"
 license = {text = "Unlicense"}

--- a/src/voice_replacer/__init__.py
+++ b/src/voice_replacer/__init__.py
@@ -5,5 +5,5 @@ A standalone Windows application that replaces user's voice from microphone
 with a neural network-synthesized voice in real-time.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "Real-Time Voice Replacement Contributors"

--- a/src/voice_replacer/__main__.py
+++ b/src/voice_replacer/__main__.py
@@ -31,8 +31,8 @@ def _setup_package_path():
 # Set up package path before any voice_replacer imports
 _setup_package_path()
 
-from .config import AppConfig
-from .gui import run_gui, run_cli
+from voice_replacer.config import AppConfig
+from voice_replacer.gui import run_gui, run_cli
 
 
 def main():
@@ -78,8 +78,8 @@ def main():
 
     # List devices if requested
     if args.list_devices:
-        from .audio_capture import AudioCapture
-        from .audio_output import AudioOutput
+        from voice_replacer.audio_capture import AudioCapture
+        from voice_replacer.audio_output import AudioOutput
 
         print("\nInput Devices (Microphones):")
         print("-" * 40)
@@ -103,7 +103,7 @@ def main():
 
     # List voices if requested
     if args.list_voices:
-        from .tts import PiperTTS
+        from voice_replacer.tts import PiperTTS
 
         print("\nAvailable Voice Models:")
         print("-" * 40)


### PR DESCRIPTION
## Summary

This PR fixes the `ImportError: attempted relative import with no known parent package` error that occurs when running the PyInstaller-bundled executable.

### Root Cause Analysis

The issue was that `__main__.py` was using **relative imports** (e.g., `from .config import AppConfig`) which require the module to be run as part of a package. When running the PyInstaller bundled `.exe` file, Python doesn't recognize the package context, causing the import error.

### Changes in This PR

1. **Converted relative imports to absolute imports** in `src/voice_replacer/__main__.py`:
   - `from .config import AppConfig` → `from voice_replacer.config import AppConfig`
   - `from .gui import run_gui, run_cli` → `from voice_replacer.gui import run_gui, run_cli`
   - `from .audio_capture import AudioCapture` → `from voice_replacer.audio_capture import AudioCapture`
   - `from .audio_output import AudioOutput` → `from voice_replacer.audio_output import AudioOutput`
   - `from .tts import PiperTTS` → `from voice_replacer.tts import PiperTTS`

2. **Bumped version to 0.1.2** (in both `pyproject.toml` and `src/voice_replacer/__init__.py`)

The existing `_setup_package_path()` function in `__main__.py` already sets up `sys.path` correctly for both development and PyInstaller bundled environments, making absolute imports work in both cases.

### Similar Issue Reference

This is the same pattern used to fix the identical issue in another project:
- https://github.com/Jhon-Crow/text-to-speech-with-chatterbox/issues/5

## Test Plan

- [x] Python syntax verified
- [x] Local unit tests pass (`tests/test_config.py`)
- [x] Code follows existing patterns
- [ ] Build executable with PyInstaller and verify no import errors
- [ ] Create release v0.1.2 after merge

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)